### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
When generating vim documentation tags, the file doc/tags is generated.
Adding it to .gitignore.
