### PR TITLE
Escape shell characters in query before running

### DIFF
--- a/autoload/dash.vim
+++ b/autoload/dash.vim
@@ -106,7 +106,7 @@ function! s:search(term, keyword) "{{{
   if !empty(keyword)
     let keyword = keyword . ':'
   endif
-  silent execute '!open dash://' . keyword . a:term
+  silent execute '!open dash://' . shellescape(keyword . a:term)
   redraw!
 endfunction
 "}}}


### PR DESCRIPTION
Otherwise some characters, for example `?` and `!` used in Ruby keywords, confuse the shell.
