### PR TITLE
Make the plugin respect the g:dash_map variable.

### DIFF
--- a/autoload/dash.vim
+++ b/autoload/dash.vim
@@ -39,6 +39,27 @@ endfunction
 "}}}
 
 let s:groups = dash#defaults#module.groups
+if !exists('g:dash_map_loaded') && exists('g:dash_map') && type(g:dash_map) == type({})
+    for pair in items(g:dash_map)
+        let ftype = pair[0]
+        let docsets = pair[1]
+
+        if (type(docsets) == type([]))
+            let s:groups[ftype] = docsets
+        elseif (type(docsets) == type(""))
+            if (!has_key(s:groups, ftype))
+                let s:groups[ftype] = []
+            else
+                call filter(s:groups[ftype], 'v:val != "' . docsets . '"')
+            endif
+            call insert(s:groups[ftype], docsets)
+        endif
+
+        unlet ftype
+        unlet docsets
+    endfor
+    let g:dash_map_loaded = 1
+endif
 
 function! dash#add_keywords_for_filetype(filetype) "{{{
   let keywords = get(s:groups, a:filetype, [])

--- a/doc/dash.txt
+++ b/doc/dash.txt
@@ -138,17 +138,44 @@ For example, add this to your |.vimrc|:
 
 Allows configuration of mappings between Vim filetypes and Dash's docsets.
 
+The variable must be a dictionary where the key is the Vim filetype you want 
+to associate and the value can be one of two kinds:
+
+List                       If the value associated with the key is a list, 
+                           than the default list of docsets used by the given 
+                           filetype is replaced by the one user defined.
+
+String                     If the value associated with the key is a simple 
+                           string, than the given docset is prepended on the 
+                           list of available docsets to the given filetype.
+
 Example:
+
+The default java docsets defined in dash.vim is this:
+>
+      ['java', 'javafx', 'grails', 'groovy', 'playjava', 'spring', 'cvj',
+       'processing', 'javadoc']
+<
+If you have this in your .vimrc:
 >
     let g:dash_map = {
-        \ 'ruby'       : 'rails',
-        \ 'python'     : 'python2',
-        \ 'javascript' : 'backbone'
+        \ 'java' : 'android'
         \ }
 <
-This setting will make searches in filetypes in the 1st column be directed to
-the docsets in the 2nd column in Dash, when they are not specified as the 2nd
-option to |:Dash| or used through the <Plug> mappings.
+The java docset will be:
+>
+      ['android', 'java', 'javafx', 'grails', 'groovy', 'playjava',
+       'spring', 'cvj', 'processing', 'javadoc']
+<
+Now if I don't want the extra docsets to be used when I'm editing a java file, 
+I could have:
+>
+    let g:dash_map = {
+        \ 'java' : ['android', 'java']
+        \ }
+<
+This would make java files have only "Android" and "Java" docsets to search 
+on.
 
 ==============================================================================
 5. License                                                       *DashLicense*


### PR DESCRIPTION
[Problem]
For some reason the documentation states that as a user I can set g:dash_map
global variable with a dictionary of "vim filetype" -> "dash docset" and
dash.vim will honor this map when calling Dash.app. Unfortunately this global
variable is never used in the plugin.

[Solution]
On autoload/dash.vim read the global variable and update the plugin map to honor
it.

[Note]
This change also makes possible to define a full list as a value on the
dictionary allowing the user to fully replace all the docsets defined by
default.
Also, the documentation was updated to reflect the change.
