### PR TITLE
Update vim-doc link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ MIT
 
 [Dash]: http://kapeli.com/
 [pathogen]: https://github.com/tpope/vim-pathogen
-[vim-doc]: http://vim-doc.heroku.com/view?https://raw.github.com/rizzatti/dash.vim/master/doc/dash.txt
+[vim-doc]: http://vim-doc.heroku.com/view?https://raw.githubusercontent.com/rizzatti/dash.vim/master/doc/dash.txt
 [vpm]: https://github.com/KevinSjoberg/vpm
 [vundle]: https://github.com/gmarik/vundle


### PR DESCRIPTION
Looks like Github changed how they do their raw links!
