### PR TITLE
Add the ability to search Dash by visually selected text

### DIFF
--- a/autoload/dash.vim
+++ b/autoload/dash.vim
@@ -41,7 +41,7 @@ endfunction
 "}}}
 
 function! dash#search(bang, search_mode, ...) "{{{
-  if a:search_mode == 'v'
+  if a:search_mode == 'visual'
     let term = getline("'<")[getpos("'<")[2]-1:getpos("'>")[2]-1]
   else
     let term = get(a:000, 0, expand('<cword>'))

--- a/autoload/dash.vim
+++ b/autoload/dash.vim
@@ -40,8 +40,13 @@ function! dash#keywords(bang, ...) "{{{
 endfunction
 "}}}
 
-function! dash#search(bang, ...) "{{{
-  let term = get(a:000, 0, expand('<cword>'))
+function! dash#search(bang, search_mode, ...) "{{{
+  if a:search_mode == 'v'
+    let term = getline("'<")[getpos("'<")[2]-1:getpos("'>")[2]-1]
+  else
+    let term = get(a:000, 0, expand('<cword>'))
+  endif
+
   let keywords = []
   if !empty(a:bang) " global search
     call s:search(term, keywords)

--- a/doc/dash.txt
+++ b/doc/dash.txt
@@ -65,6 +65,11 @@ Examples:
     Will search for the word under the cursor in the docset corresponding to
     the current filetype.
     >
+    :DashVisual
+>
+    Will search for visually selected text in the docset corresponding to
+    the current filetype
+    >
     :Dash printf
 <
     Will search for the word 'printf' in the docset corresponding to the
@@ -122,12 +127,17 @@ This plugin provides helpful mappings for common use cases.
                               considering the current keyword setup for
                               docset lookup.
 
+<Plug>DashVisual            Searches for the text currently selected in
+                              visual mode, considering the current keyword
+                              setup for docset lookup.
+
 <Plug>DashGlobalSearch      Searches for the |word| under the cursor in all
                               docsets.
 
 For example, add this to your |.vimrc|:
     >
     :nmap <silent> <leader>d <Plug>DashSearch
+    :vmap <silent> <leader>d <Plug>DashVisual
 <
     Note: Using |:noremap| will not work with <Plug> mappings.
 

--- a/doc/dash.txt
+++ b/doc/dash.txt
@@ -66,7 +66,7 @@ Examples:
     the current filetype.
     >
     :DashVisual
->
+<
     Will search for visually selected text in the docset corresponding to
     the current filetype
     >

--- a/plugin/dash.vim
+++ b/plugin/dash.vim
@@ -20,8 +20,8 @@ if exists(':Dash') == 2
   echomsg 'dash.vim: could not create command Dash'
   echohl None
 else
-  command -bang -complete=customlist,dash#complete -nargs=* -count=1 Dash call dash#search("<bang>", 'n', <f-args>)
-  command -bang -complete=customlist,dash#complete -nargs=* -count=1 DashVisual call dash#search("<bang>", 'v', <f-args>)
+  command -bang -complete=customlist,dash#complete -nargs=* -count=1 Dash call dash#search("<bang>", 'normal', <f-args>)
+  command -bang -complete=customlist,dash#complete -nargs=* -count=1 DashVisual call dash#search("<bang>", 'visual', <f-args>)
 
   "{{{ <Plug> mappings
   noremap <script> <unique> <Plug>DashSearch :Dash<CR>

--- a/plugin/dash.vim
+++ b/plugin/dash.vim
@@ -20,13 +20,13 @@ if exists(':Dash') == 2
   echomsg 'dash.vim: could not create command Dash'
   echohl None
 else
-  command -bang -complete=customlist,dash#complete -nargs=* -count=1 Dash call dash#search("<bang>", <f-args>)
+  command -bang -complete=customlist,dash#complete -nargs=* -count=1 Dash call dash#search("<bang>", 'n', <f-args>)
+  command -bang -complete=customlist,dash#complete -nargs=* -count=1 DashV call dash#search("<bang>", 'v', <f-args>)
 
   "{{{ <Plug> mappings
-  noremap <script> <unique> <Plug>DashSearch <SID>DashSearch
-  noremap <SID>DashSearch :Dash<CR>
-  noremap <script> <unique> <Plug>DashGlobalSearch <SID>DashGlobalSearch
-  noremap <SID>DashGlobalSearch :Dash!<CR>
+  noremap <script> <unique> <Plug>DashSearch :Dash<CR>
+  noremap <script> <unique> <Plug>DashVisual :DashV<CR>
+  noremap <script> <unique> <Plug>DashGlobalSearch :Dash!<CR>
   "}}}
 endif
 "}}}

--- a/plugin/dash.vim
+++ b/plugin/dash.vim
@@ -21,11 +21,11 @@ if exists(':Dash') == 2
   echohl None
 else
   command -bang -complete=customlist,dash#complete -nargs=* -count=1 Dash call dash#search("<bang>", 'n', <f-args>)
-  command -bang -complete=customlist,dash#complete -nargs=* -count=1 DashV call dash#search("<bang>", 'v', <f-args>)
+  command -bang -complete=customlist,dash#complete -nargs=* -count=1 DashVisual call dash#search("<bang>", 'v', <f-args>)
 
   "{{{ <Plug> mappings
   noremap <script> <unique> <Plug>DashSearch :Dash<CR>
-  noremap <script> <unique> <Plug>DashVisual :DashV<CR>
+  noremap <script> <unique> <Plug>DashVisual :DashVisual<CR>
   noremap <script> <unique> <Plug>DashGlobalSearch :Dash!<CR>
   "}}}
 endif


### PR DESCRIPTION
For example when performing a search on the line of code:
```elixir
def values(range), do: Enum.map(range, &convert/1)
```


If you wanted to search for <code>Enum.map</code>, you would have previously been unable to as only the word under the cursor could be searched for. These changes allow for visually selected text to be search for without changing current functionality.