### PR TITLE
Add support for velocity on windows for WSL in windows

### DIFF
--- a/autoload/dash.vim
+++ b/autoload/dash.vim
@@ -119,7 +119,12 @@ function! s:search(term, keywords) "{{{
     let activation = ''
   endif
   let url = 'dash-plugin://' . shellescape(keys . query . activation)
-  silent execute '!open -g ' . url
+  let open_program = 'open -g '
+
+  if (executable('wslview') == 1)
+    let open_program = 'wslview '
+  endif
+  silent execute '!' . open_program . url
   redraw!
 endfunction
 "}}}


### PR DESCRIPTION
This adds support to search the docs in "Velocity" on Windows via WSL.

I have vim installed in WSL on windows and "Velocity" installed in windows. This helps search docs from vim inside WSL directly on windows Velocity.

Fixes - https://github.com/rizzatti/dash.vim/issues/61