### PR TITLE
Add option to remote trigger Dash on non-macOS systems

### DIFF
--- a/autoload/dash.vim
+++ b/autoload/dash.vim
@@ -119,7 +119,13 @@ function! s:search(term, keywords) "{{{
     let activation = ''
   endif
   let url = 'dash-plugin://' . shellescape(keys . query . activation)
-  silent execute '!open -g ' . url
+
+  if exists('g:dash_remote_domain')
+    silent execute '!ssh ' . d:dash_remote_domain . ' "open -g' . url . '"'
+  else
+    silent execute '!open -g' . url
+  endif
+
   redraw!
 endfunction
 "}}}

--- a/plugin/dash.vim
+++ b/plugin/dash.vim
@@ -6,7 +6,7 @@ if exists('loaded_dash') || &compatible || v:version < 700
   finish
 endif
 
-if !has('unix') " OS X's vim and MacVim have this feature
+if !has('unix') && !exists('g:dash_remote_domain') " OS X's vim and MacVim have this feature
   finish
 endif
 let loaded_dash = 1


### PR DESCRIPTION
I really like the idea of using this plugin

But recently I changed my setup. I have a PC with Linux installed. I'm using SSH to connect to it and I work on my MBP. Due to that problem, I wasn't able to use this plugin. Now I added a small change, so instead of triggering `open` on local machine, I can do it via ssh on some other machine - in my case, on my MBP. I only need to add `let g:dash_remote_domain="my_IP_or_local_domain"` in config file.